### PR TITLE
Install rsync dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:2.7
 
 MAINTAINER SG Finans <frontutvikling@sgfinans.no>
 
+RUN apt-get update && apt-get install -y rsync
 RUN pip install fabric
 
 WORKDIR /app


### PR DESCRIPTION
Rsync is not installed in python:2.7 and is necessary for Fabric's `rsync_project`.

Build success for this modification is visible here: https://hub.docker.com/r/erikreed/docker-fabric/builds/bvnmbdkaewmv7ms9hr2pf9j/